### PR TITLE
Fix metadata for multitensor

### DIFF
--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -73,6 +73,10 @@ class TestMultiTensor(unittest.TestCase):
     sharded_arange.realize()
     np.testing.assert_equal(sharded_arange.numpy(), np.arange(1000))
 
+  def test_metadata(self):
+    t = Tensor.arange(4).realize().shard(devices_2, 0)
+    self.assertEqual(t.uop.metadata[0].name, "shard")
+
   # TODO: fix this to not copy on the src device
   @unittest.expectedFailure
   def test_shard_no_recompile(self):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -398,8 +398,7 @@ class Tensor(MathTrait):
     """
     assert isinstance(self.device, str), "can't shard a MultiLazyBuffer"
     devices = tuple(Device.canonicalize(x) for x in devices)
-    mlb = self.uop.shard(devices, self._resolve_dim(axis)) if axis is not None else self.uop.copy_to_device(devices)
-    return Tensor(mlb, device=devices, requires_grad=self.requires_grad)
+    return self._apply_uop(lambda x: x.shard(devices, self._resolve_dim(axis)) if axis is not None else x.copy_to_device(devices))
 
   def shard_(self, devices:tuple[str, ...], axis:int|None=None) -> Tensor:
     """


### PR DESCRIPTION
## Summary
- attach metadata to multitensor ops by routing through `_apply_uop`
- test that sharding tensors sets the expected metadata